### PR TITLE
Make noVNC listen on localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - DISPLAY_WIDTH=1600
       - DISPLAY_HEIGHT=968
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     networks:
       - x11
 networks:


### PR DESCRIPTION
Listening on the wildcard address is a dangerous default, and could cause security problems, especially since there is currently no authentication in the pcstudio-novnc container.

There is even a PR to change this behavior: https://github.com/theasp/docker-novnc/pull/6/files